### PR TITLE
kubectl jfs po output need a \n when no pod

### DIFF
--- a/pkg/list/pod.go
+++ b/pkg/list/pod.go
@@ -134,7 +134,7 @@ func (aa *AppAnalyzer) JfsPod() error {
 	}
 
 	if len(appPods) == 0 {
-		fmt.Printf("No pod found using juicefs PVC in %s namespace.", aa.ns)
+		fmt.Printf("No pod found using juicefs PVC in %s namespace.\n", aa.ns)
 		return nil
 	}
 


### PR DESCRIPTION
current:
<img width="683" alt="image" src="https://github.com/juicedata/kubectl-jfs-plugin/assets/11989040/bef5f22e-a5cf-4751-be48-c38640fe3850">
